### PR TITLE
Use 'exists' when it's enough and do not stringify an object excess time...

### DIFF
--- a/lib/QBit/TimeLog.pm
+++ b/lib/QBit/TimeLog.pm
@@ -71,7 +71,7 @@ sub init {
 
     $self->SUPER::init();
 
-    weaken($self->{'parent'}) if $self->{'parent'};
+    weaken($self->{'parent'}) if exists($self->{'parent'});
 }
 
 =head1 Methods


### PR DESCRIPTION
....
